### PR TITLE
Add moodle ansible moodle to check for moodle status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.retry
 .idea/
-
+*.pyc

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ This role was created in 2017 by [Laurent David](https://github.com/laurentdavid
 We have used Jeff Geerling's tests as a base, so:
 
 - Test should run on travis  
-- Locally you can start the test process using the command `./tests/test.sh`
+- Locally you can start the test process using the command
+
+        ./tests/test.sh
+    
+    The docker instance is destroyed at the end of the test, but you can keep it by setting the
+     environment variable "cleanup" to "false":
+     
+        cleanup="false" ./tests/test.sh
+     
 - Once the docker has been launch you can rerun the playbook by running:
 ```bash
     container_id=xxxxyyy
@@ -50,4 +58,17 @@ We have used Jeff Geerling's tests as a base, so:
 Prerequisites are to have docker installed locally.
 It will run the tests on postgresql. 
 
+### Library testing
+There is a small module that checks if moodle is installed/configured in the library folder.
+To test it you need to install nose
 
+    pip install nose
+    
+Then:
+
+    cd library
+    nosetests -v test_check_moodle.py
+    
+You can also test it using a mini test playbook:
+
+    ansible-playbook -i 'localhost,' tests/test-check-moodle.yml 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,8 @@ We have used Jeff Geerling's tests as a base, so:
 ```
 
 Prerequisites are to have docker installed locally.
-It will run the tests on postgresql. 
+It will run the tests on postgresql only. More info in the README.md file in the tests folder.
 
 ### Library testing
 There is a small module that checks if moodle is installed/configured in the library folder.
-To test it you need to install nose
-
-    pip install nose
-    
-Then:
-
-    cd library
-    nosetests -v test_check_moodle.py
-    
-You can also test it using a mini test playbook:
-
-    ansible-playbook -i 'localhost,' tests/test-check-moodle.yml 
+More info in the README.md of the library folder.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-
+# Handle moodle installation (i.e. the setup process). We assume here that the config.php has been set and is valid
 - name: moodle installer
   listen: install moodle
   command: >
@@ -8,6 +8,7 @@
   args:
     chdir: "{{ moodle_src_path }}"
 
+# Handle moodle upgrade if needed
 - name: moodle upgrader
   listen: upgrade moodle
   command: >

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,17 @@
 ---
 
 - name: moodle installer
-  listen: intiate moodle configuration
+  listen: install moodle
   command: >
     php admin/cli/install_database.php --adminuser={{ moodle_site_admin.username }} --adminpass={{ moodle_site_admin.password }}
     --adminemail={{ moodle_site_admin.email }} --agree-license --fullname={{ moodle_site_fullname }} --shortname={{ moodle_site_shortname }}
+  args:
+    chdir: "{{ moodle_src_path }}"
+
+- name: moodle upgrader
+  listen: upgrade moodle
+  command: >
+    php admin/cli/upgrade.php --non-interactive
   args:
     chdir: "{{ moodle_src_path }}"
 

--- a/library/README.md
+++ b/library/README.md
@@ -1,0 +1,33 @@
+# Check Moodle state module
+
+This module is intended to check Moodle state (installed, to be upgraded) so we can take decision regarding
+what needs to be done in term of setting it up.
+
+    - name: Moodle - Check the state of current moodle
+      check_moodle:
+        install_dir: "{{ moodle_src_path }}"
+      register: moodle_state
+
+The moodle_state will have the following values:
+
+* msg: an error message if any (this contains the error message sent by moodle, for example if we cannot
+connect to existing database)
+* code: error code if any (from moodle)
+* moodle_needs_upgrading: boolean - moodle needs upgrading
+* moodle_is_installed: boolean - moodle is installed (a *valid* config file is there)
+
+The process can also fail if the PHP CLI command (`php`) does not work or the provided folder is not a moodle folder.
+
+## Testing 
+To test it you need to install nose
+
+    pip install nose
+    
+Then:
+
+    cd library
+    nosetests -v test_check_moodle.py
+    
+You can also test it using a mini test playbook:
+
+    ansible-playbook -i 'localhost,' tests/test-check-moodle.yml 

--- a/library/check_moodle.py
+++ b/library/check_moodle.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+import pwd
+from ansible.module_utils.basic import AnsibleModule
+
+
+class CheckMoodle:
+    """This class will check if the moodle installed in the install_dir and conduct the following checks:
+        - Check that dependencies are installed no php installed, libraries not installed, etc...)
+        - The configuration file is present and we can connect to the database
+        - The database has been installed
+        - Moodle needs to be updated
+
+    """
+    def __init__(self, install_dir):
+        self.install_dir = install_dir
+
+    # Check if user exists
+    def check_moodle(self):
+        try:
+            # First check that we can use php cli
+
+
+        except KeyError:
+            success = False
+            ret_msg = 'User %s does not exists' % self.user
+        return success, ret_msg, uid, gid
+
+def main():
+    # Parsing argument file
+    module = AnsibleModule(
+        argument_spec = dict(
+            install_dir = dict(required=True)
+        )
+    )
+    install_dir = module.params.get('install_dir')
+
+    chkmoodle = CheckMoodle(install_dir)
+    success, ret_msg, uid, gid = chkmoodle.check_moodle()
+
+    # Error handling and JSON return
+    if success:
+        module.exit_json(msg=ret_msg, uid=uid, gid=gid)
+    else:
+        module.fail_json(msg=ret_msg)
+
+if __name__ == "__main__":
+    main()

--- a/library/check_moodle.py
+++ b/library/check_moodle.py
@@ -1,29 +1,62 @@
 #!/usr/bin/env python
-import pwd
+import os
+import subprocess
+import json
+
 from ansible.module_utils.basic import AnsibleModule
 
-
-class CheckMoodle:
+class CheckMoodle(object):
     """This class will check if the moodle installed in the install_dir and conduct the following checks:
-        - Check that dependencies are installed no php installed, libraries not installed, etc...)
+        - Check that PHP cli is installed (prerequisite)
         - The configuration file is present and we can connect to the database
-        - The database has been installed
+        - The database has been installed/setup
         - Moodle needs to be updated
-
     """
     def __init__(self, install_dir):
         self.install_dir = install_dir
 
-    # Check if user exists
+    """ Check if PHP is installed. This should be a private method but stayed public for unit testing    
+    """
+    def do_check_php_cli_installed(self):
+        subprocess.check_call(["php","-v"])
+
+    """ Check if Moodle is installed and / or configured. This should be a private method but stayed public for unit testing    
+    """
+    def do_check_moodle(self):
+        read, write = os.pipe()
+        os.write(write, phpscript)
+        os.close(write)
+        output = subprocess.check_output(["php","--", "-m " + self.install_dir], stdin=read)
+        return json.loads(output)
+
+    """ Checks if mooodle is installed or not
+    """
     def check_moodle(self):
+        retvalue = {
+            "fatalerror": False,
+            "errormsg": "",
+            "errorcode": "",
+            "oldversion": False,
+            "newversion": False,
+            "moodle_needs_upgrading": False,
+            "moodle_is_installed": False
+        }
+
         try:
             # First check that we can use php cli
+            self.do_check_php_cli_installed()
+            # Secondly launch the moodlecheck script in PHP
+            retvalue = self.do_check_moodle()
 
+        except subprocess.CalledProcessError:
+            retvalue["fatalerror"] = True
+            retvalue["errormsg"] = CheckMoodle.error_php_not_present['msg']
+            retvalue["errorcode"] = CheckMoodle.error_php_not_present['code']
+        return retvalue
 
-        except KeyError:
-            success = False
-            ret_msg = 'User %s does not exists' % self.user
-        return success, ret_msg, uid, gid
+    # Error messages
+    error_php_not_present = { "code": "phpclinotpresent", "msg": "PHP command CLI not present"}
+
 
 def main():
     # Parsing argument file
@@ -35,13 +68,107 @@ def main():
     install_dir = module.params.get('install_dir')
 
     chkmoodle = CheckMoodle(install_dir)
-    success, ret_msg, uid, gid = chkmoodle.check_moodle()
+    retvalue = chkmoodle.check_moodle()
 
     # Error handling and JSON return
-    if success:
-        module.exit_json(msg=ret_msg, uid=uid, gid=gid)
+    if not(retvalue["fatalerror"]):
+        module.exit_json(
+                msg=retvalue["errormsg"],
+                code=retvalue["errorcode"],
+                moodle_needs_upgrading = retvalue["moodle_needs_upgrading"],
+                moodle_is_installed = retvalue["moodle_is_installed"])
     else:
-        module.fail_json(msg=ret_msg)
+        module.fail_json(
+                msg=retvalue["errormsg"],
+                code = retvalue["errorcode"]
+        )
+
+phpscript = '''
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * CLI script to check the status of Moodle.
+ * @package     ansible-role-moodle
+ * @copyright   2018 Laurent David <laurent@call-learning.fr>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+
+$options = getopt("m:", array('moodlepath'));
+
+$returnvalue = new stdClass();
+$returnvalue->fatalerror = false; // This type of error is the one we cannot recover from and is not due to the moodle setup
+$returnvalue->errorcode = "";
+$returnvalue->errormsg = "";
+$returnvalue->oldversion = "";
+$returnvalue->newversion = "";
+$returnvalue->moodle_needs_upgrading = false;
+$returnvalue->moodle_is_installed = false;
+
+$moodlepath = array_key_exists('m', $options) ? $options['m'] : null;
+$moodlepath = (is_null($moodlepath) && array_key_exists('moodlepath', $options)) ? $options['moodlepath'] : $moodlepath;
+
+if (is_null($moodlepath)) {
+    $returnvalue->fatalerror = true;
+    $returnvalue->errorcode = "wrongmoodlepath";
+    $returnvalue->errormsg = "Wrong Moodle Path Provided: cannot find a moodle installed here";
+    print json_encode($returnvalue);
+    exit(1);
+}
+
+// Check first if moodle is installed
+$configpath = realpath($moodlepath . '/config.php');
+
+if (!file_exists($configpath)) {
+    $returnvalue->moodle_is_installed = false;
+    print json_encode($returnvalue);
+    exit(0);
+}
+
+// Now we are sure it is installed check it it needs upgrading
+try {
+    ini_set('display_errors', '0');
+    ini_set('log_errors', 0);
+    define('NO_DEBUG_DISPLAY', true); // Do not display error on the command line
+    require_once($configpath);
+    global $DB;
+
+    if (!$DB->get_manager()->table_exists('config')) {
+        print json_encode($returnvalue);
+        exit(0);
+    }
+
+    require_once($CFG->libdir . '/adminlib.php');       // various admin-only functions
+    require_once($CFG->libdir . '/upgradelib.php');     // general upgrade/install related functions
+    require_once($CFG->libdir . '/environmentlib.php');
+
+    require("$CFG->dirroot/version.php");       // defines $version, $release, $branch and $maturity
+    $returnvalue->oldversion = "$CFG->release ($CFG->version)";
+    $returnvalue->newversion = "$release ($version)";
+    $returnvalue->moodle_needs_upgrading = moodle_needs_upgrading();
+    $returnvalue->moodle_is_installed = true;
+} catch (Exception $e) {
+    $returnvalue->errorcode = $e->errorcode;
+    $returnvalue->errormsg = $e->getMessage();
+}
+print json_encode($returnvalue);
+exit(0);
+'''
 
 if __name__ == "__main__":
     main()

--- a/library/test_check_moodle.py
+++ b/library/test_check_moodle.py
@@ -1,0 +1,46 @@
+from nose.tools import assert_equals, assert_false, assert_true
+from check_moodle import CheckMoodle
+import json
+import subprocess
+
+class MockedCheckMoodle(CheckMoodle):
+    __is_php_installed = False
+    __moodle_check_return = ""
+
+    def __init__(self, install_dir, php_installed, check_moodle_return):
+        super(self.__class__, self).__init__(install_dir)
+        self.__is_php_installed = php_installed
+        self.__moodle_check_return = check_moodle_return
+
+    def do_check_php_cli_installed(self):
+        if not self.__is_php_installed:
+            raise subprocess.CalledProcessError(127, "php -v")
+
+    def do_check_moodle(self):
+        return json.loads(self.__moodle_check_return)
+
+
+def test_check_php_not_installed():
+    moodlecheck = MockedCheckMoodle("/var/www/moodle/",False, "")
+    retvalue = moodlecheck.check_moodle()
+    assert_equals(retvalue['errorcode'], CheckMoodle.error_php_not_present['code'])
+
+def test_check_wrong_moodle_path():
+    moodlecheck = MockedCheckMoodle("/var/www/moodle/",True,
+                                    '{"error":true,"errorcode":"wrongmoodlepath","errormsg":"Wrong Moodle Path","oldversion":"","newversion":"","moodle_need_upgrading":false}')
+    retvalue = moodlecheck.check_moodle()
+    assert_equals(retvalue['errorcode'], "wrongmoodlepath")
+
+def test_check_moodle_not_installed():
+    moodlecheck = MockedCheckMoodle("/var/www/moodle/",True,
+                                    '{"error":false,"errorcode":"","errormsg":"","oldversion":"","newversion":"","moodle_need_upgrading":false,"moodle_is_installed":false}')
+    retvalue = moodlecheck.check_moodle()
+    assert_equals(retvalue['errorcode'], "")
+    assert_false(retvalue['moodle_is_installed'])
+
+def test_check_moodle_needs_upgrading():
+    moodlecheck = MockedCheckMoodle("/var/www/moodle/",True,
+                                    '{"error":false,"errorcode":"","errormsg":"","oldversion":"","newversion":"","moodle_need_upgrading":true,"moodle_is_installed":true}')
+    retvalue = moodlecheck.check_moodle()
+    assert_equals(retvalue['errorcode'], "")
+    assert_true(retvalue['moodle_need_upgrading'])

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,16 +8,9 @@ galaxy_info:
   license: "license (BSD, MIT)"
   min_ansible_version: 2.5
   platforms:
-  - name: EL
-    versions:
-    - 6
-    - 7
-  - name: Fedora
-    versions:
-    - all
   - name: Debian
     versions:
-    - all
+    - stretch
   - name: Ubuntu
     versions:
     - trusty

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Moodle RedHat/CentOS/Fedora/Debian/Ubuntu.
   company: "SAS CALL Learning"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   platforms:
   - name: EL
     versions:

--- a/tasks/fetchsources.yml
+++ b/tasks/fetchsources.yml
@@ -1,5 +1,5 @@
 ---
-
+# Fetch moodle source from a git repository
 - name: Moodle- Install Moodle source code in the destination folder
   git:
     repo: "{{ moodle_git_url }}"

--- a/tasks/fetchsources.yml
+++ b/tasks/fetchsources.yml
@@ -5,4 +5,5 @@
     repo: "{{ moodle_git_url }}"
     dest: "{{ moodle_src_path }}"
     version: "{{ moodle_version }}"
+    depth: 1 # Only shallow cloning. Can be fixed if needed later to have the full history (git pull --unshallow)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,28 @@
 - import_tasks: setupdirs.yml
 - import_tasks: fetchsources.yml
 
-- name: Moodle - Create config template and trigger install
-  template:
-    src: config.php.j2
-    dest: "{{ moodle_src_path }}/config.php"
-    mode: 0644
-  notify: intiate moodle configuration
-  when: moodle_run_config|bool and moodle_site_source_stat is defined and not moodle_site_source_stat.stat.exists
+- name: Verify Ansible meets version requirements
+  assert:
+    that: "ansible_version.full is version_compare('2.5', '>=')"
+  msg: "You must update Ansible to at least 2.5 to use this role."
+
+- name: Moodle - Check the state of current moodle
+  check_moodle:
+    install_dir: "{{ moodle_src_path }}"
+  register: moodle_state
+
+- name: Moodle - create config and install moodle
+  block:
+    - template:
+        src: config.php.j2
+        dest: "{{ moodle_src_path }}/config.php"
+        mode: 0644
+      notify: install moodle
+  when: moodle_run_config|bool and moodle_site_source_stat is defined and not moodle_state.moodle_is_installed|bool
+
+
+- name: Moodle - Launch update
+  command:  /bin/true
+  notify: upgrade moodle
+  when: moodle_run_config|bool and moodle_site_source_stat is defined and not moodle_state.moodle_needs_upgrading|bool
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     that: "ansible_version.full is version_compare('2.5', '>=')"
   msg: "You must update Ansible to at least 2.5 to use this role."
 
+# This is using our custom module to check moodle state
 - name: Moodle - Check the state of current moodle
   check_moodle:
     install_dir: "{{ moodle_src_path }}"
@@ -23,8 +24,8 @@
   when: moodle_run_config|bool and moodle_site_source_stat is defined and not moodle_state.moodle_is_installed|bool
 
 
-- name: Moodle - Launch update
+- name: Moodle - Launch update (if needed)
   command:  /bin/true
   notify: upgrade moodle
-  when: moodle_run_config|bool and moodle_site_source_stat is defined and not moodle_state.moodle_needs_upgrading|bool
+  when: moodle_run_config|bool and moodle_site_source_stat is defined and moodle_state.moodle_needs_upgrading|bool
 

--- a/tasks/setupdirs.yml
+++ b/tasks/setupdirs.yml
@@ -1,4 +1,7 @@
 ---
+# Creates the relevant directories to install moodle:
+# - a source directory
+# - a data directory where we will have all site data
 - name: Moodle- Check before if installation directory exists
   stat:
     path: "{{ moodle_src_path }}/config.php"

--- a/tests/test-check-moodle.yml
+++ b/tests/test-check-moodle.yml
@@ -1,0 +1,13 @@
+---
+
+# You can run this script by providing this playbook and the value of a real moodle install
+
+- hosts: localhost
+  gather_facts: yes
+  connection: local
+
+  tasks:
+    - name: Check the state of current moodle
+      check_moodle:
+        install_dir: "."
+      register: moodle_state

--- a/tests/test-handlers.yml
+++ b/tests/test-handlers.yml
@@ -20,4 +20,8 @@
   tasks:
     - name: Moodle - Trigger installation
       command: /bin/true
-      notify: intiate moodle configuration
+      notify: install moodle
+
+    - name: Moodle - Trigger installation
+      command: /bin/true
+      notify: update moodle

--- a/tests/test-setup.yml
+++ b/tests/test-setup.yml
@@ -37,6 +37,7 @@
       - php7.0-xmlrpc
       - php7.0-zip
       - php7.0-fpm
+      - php-apcu
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Set php_packages for PHP CentOS/Redhat from REMI package.

--- a/tests/test-setup.yml
+++ b/tests/test-setup.yml
@@ -37,7 +37,7 @@
       - php7.0-xmlrpc
       - php7.0-zip
       - php7.0-fpm
-      - php-apcu
+      - php-apcu  # Important for the command line
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Set php_packages for PHP CentOS/Redhat from REMI package.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -27,6 +27,7 @@ playbook=${playbook:-"test.yml"}
 cleanup=${cleanup:-"true"}
 container_id=${container_id:-$timestamp}
 test_idempotence=${test_idempotence:-"true"}
+publish_port={publish_port:-""} # Add publish_port="-p 8000:80" to forward port 80 to 8000
 
 ## Set up vars for Docker setup.
 # CentOS 7
@@ -69,7 +70,7 @@ opts="$opts --add-host moodle.test:127.0.0.1 "
 # Run the container using the supplied OS.
 printf ${green}"Starting Docker container: geerlingguy/docker-$distro-ansible."${neutral}"\n"
 docker pull geerlingguy/docker-$distro-ansible:latest
-docker run --detach --volume="$PWD":/etc/ansible/roles/role_under_test:rw --name $container_id $opts geerlingguy/docker-$distro-ansible:latest $init
+docker run $publish_port --detach --volume="$PWD":/etc/ansible/roles/role_under_test:rw --name $container_id $opts geerlingguy/docker-$distro-ansible:latest $init
 
 printf "\n"
 


### PR DESCRIPTION
The aim of this PR is to enable ansible to quickly get a status of an moodle instance (installed, to be upgraded...) so we can use it in an automated deployment as a local script.

This PR contains also a couple of fixes to the main scripts and test scripts.